### PR TITLE
Force the TZ in maven for the test for proper date/time testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.18.1</version>
+          <configuration>
+            <!-- Force the time zone to the PDT timezone to ensure proper parsing of date/time strings -->
+            <argLine>-Duser.timezone=GMT-07</argLine>
+          </configuration>
         </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Tests were not passing when computer is not in PDT TZ, this is due to the various way of parsing date/time/ts string.

I have forced the timezone in the sure fire plugin. (pom.xml)

http://github.com/ojai/ojai/issues/2
